### PR TITLE
Remove superfluous pointer checks and fix possible leaks and double free

### DIFF
--- a/common.c
+++ b/common.c
@@ -48,6 +48,7 @@ char *grep_awk(FILE *fp, const char *fstr, int nfield, const char *delim) {
   free(line);
   return NULL;
 error:
+  free(line);
   return NULL;
 }
 

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -269,11 +269,12 @@ error:
 static char *get_cmdline(pid_t pid) {
   FILE *fp = NULL;
   char procfile[50];
-  char *contents;
+  char *contents = NULL;
   int bufsize = 500;
   ssize_t read;
 
   contents = (char *)calloc(bufsize, sizeof(char));
+  check_mem(contents);
   sprintf(procfile, "/proc/%d/cmdline", pid);
   fp = fopen(procfile, "r");
   check(fp, "Couldn't open process cmdline file");
@@ -525,17 +526,18 @@ void free_disk_partition_info(DiskPartitionInfo *di) {
 
 DiskIOCounterInfo *disk_io_counters() {
   const int sector_size = 512;
-
-  char *line = (char *)calloc(150, sizeof(char));
-  char **partitions = (char **)calloc(30, sizeof(char *));
-
+  char *line = NULL;
+  char **partitions = NULL;
   char *tmp;
   int i = 0, nparts = 0;
   size_t nmemb;
   DiskIOCounters *counters = NULL;
   DiskIOCounters *ci = NULL;
-  DiskIOCounterInfo *ret =
-      (DiskIOCounterInfo *)calloc(1, sizeof(DiskIOCounterInfo));
+  DiskIOCounterInfo *ret = NULL;
+
+  line = (char *)calloc(150, sizeof(char));
+  partitions = (char **)calloc(30, sizeof(char *));
+  ret = (DiskIOCounterInfo *)calloc(1, sizeof(DiskIOCounterInfo));
 
   FILE *fp = fopen("/proc/partitions", "r");
   check(fp, "Couldn't open /proc/partitions");
@@ -624,7 +626,8 @@ error:
     }
     free(partitions);
   }
-  free_disk_iocounter_info(ret);
+  if(ret)
+    free_disk_iocounter_info(ret);
 
   return NULL;
 }
@@ -641,15 +644,19 @@ void free_disk_iocounter_info(DiskIOCounterInfo *di) {
 
 NetIOCounterInfo *net_io_counters() {
   FILE *fp = NULL;
-  NetIOCounterInfo *ret =
-      (NetIOCounterInfo *)calloc(1, sizeof(NetIOCounterInfo));
-  NetIOCounters *counters = (NetIOCounters *)calloc(15, sizeof(NetIOCounters));
-  NetIOCounters *nc = counters;
+  NetIOCounterInfo *ret = NULL;
+  NetIOCounters *counters = NULL;
+  NetIOCounters *nc = NULL;
   int i = 0, ninterfaces = 0;
-  char *line = (char *)calloc(200, sizeof(char));
+  char *line = NULL;
   char *tmp = NULL;
+
+  ret = (NetIOCounterInfo *)calloc(1, sizeof(NetIOCounterInfo));
+  counters = (NetIOCounters *)calloc(15, sizeof(NetIOCounters));
+  line = (char *)calloc(200, sizeof(char));
   check_mem(line);
   check_mem(counters);
+  nc = counters;
   check_mem(ret);
   fp = fopen("/proc/net/dev", "r");
   check(fp, "Couldn't open /proc/net/dev");
@@ -780,8 +787,9 @@ uint32_t get_boot_time() {
   char *tmp = NULL;
   unsigned long ret = -1;
   FILE *fp = fopen("/proc/stat", "r");
-  char *line = (char *)calloc(200, sizeof(char));
+  char *line = NULL;
   check(fp, "Couldn't open /proc/stat");
+  line = (char *)calloc(200, sizeof(char));
   check_mem(line);
 
   while (fgets(line, 150, fp)) {

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -703,7 +703,7 @@ error:
     fclose(fp);
   free(line);
   free(counters);
-  free(nc);
+  free(ret);
   return NULL;
 }
 

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -561,6 +561,7 @@ DiskIOCounterInfo *disk_io_counters() {
     }
   }
   fclose(fp);
+  fp = NULL;
 
   nmemb = nparts;
   counters = (DiskIOCounters *)calloc(nparts, sizeof(DiskIOCounters));

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -74,9 +74,7 @@ static CpuTimes *calculate_cpu_times_percentage(CpuTimes *t1, CpuTimes *t2) {
   return ret;
 
 error:
-  if (ret) {
-    free(ret);
-  }
+  free(ret);
   return NULL;
 }
 
@@ -177,9 +175,7 @@ char **get_physical_devices(size_t *ndevices) {
 error:
   if (fs)
     fclose(fs);
-  if (line) {
-    free(line);
-  }
+  free(line);
   if (*ndevices != 0)
     for (i = 0; i < *ndevices; i++)
       free(retval[i]);
@@ -266,9 +262,7 @@ static char *get_exe(pid_t pid) {
 error:
   if (fp)
     fclose(fp);
-  if (tmp) {
-    free(tmp);
-  }
+  free(tmp);
   return NULL;
 }
 
@@ -296,9 +290,7 @@ static char *get_cmdline(pid_t pid) {
 error:
   if (fp)
     fclose(fp);
-  if (contents) {
-    free(contents);
-  }
+  free(contents);
   return NULL;
 }
 
@@ -401,9 +393,7 @@ static char *get_terminal(pid_t pid) {
 error:
   if (fp)
     fclose(fp);
-  if (tmp) {
-    free(tmp);
-  }
+  free(tmp);
   return NULL;
 }
 
@@ -626,9 +616,7 @@ DiskIOCounterInfo *disk_io_counters() {
 error:
   if (fp)
     fclose(fp);
-  if (line) {
-    free(line);
-  }
+  free(line);
   if (partitions) {
     for (i = 0; i < nparts; i++) {
       free(partitions[i]);
@@ -713,15 +701,9 @@ error:
   /* TODO: ret not freed here */
   if (fp)
     fclose(fp);
-  if (line) {
-    free(line);
-  }
-  if (counters) {
-    free(counters);
-  }
-  if (nc) {
-    free(nc);
-  }
+  free(line);
+  free(counters);
+  free(nc);
   return NULL;
 }
 
@@ -821,12 +803,8 @@ uint32_t get_boot_time() {
 error:
   if (fp)
     fclose(fp);
-  if (line) {
-    free(line);
-  }
-  if (tmp) {
-    free(tmp);
-  }
+  free(line);
+  free(tmp);
   return -1;
 }
 
@@ -879,9 +857,7 @@ bool virtual_memory(VmemInfo *ret) {
 error:
   if (fp)
     fclose(fp);
-  if (line) {
-    free(line);
-  }
+  free(line);
   return false;
 }
 
@@ -931,9 +907,7 @@ bool swap_memory(SwapMemInfo *ret) {
 error:
   if (fp)
     fclose(fp);
-  if (line) {
-    free(line);
-  }
+  free(line);
   return false;
 }
 
@@ -979,12 +953,8 @@ CpuTimes *cpu_times(bool percpu) {
 error:
   if (fp)
     fclose(fp);
-  if (line) {
-    free(line);
-  }
-  if (ret) {
-    free(ret);
-  }
+  free(line);
+  free(ret);
   return NULL;
 }
 
@@ -1006,9 +976,7 @@ CpuTimes *cpu_times_percent(bool percpu, CpuTimes *prev_times) {
   free(current);
   return ret;
 error:
-  if (current) {
-    free(current);
-  }
+  free(current);
   return NULL;
 }
 
@@ -1027,9 +995,7 @@ double *cpu_util_percent(bool percpu, CpuTimes *prev_times) {
   free(current);
   return percentage;
 error:
-  if (current) {
-    free(current);
-  }
+  free(current);
   return NULL;
 }
 
@@ -1098,10 +1064,8 @@ Process *get_process(pid_t pid) {
   }
 
   retval->terminal = get_terminal(pid);
-  if (uids)
-    free(uids);
-  if (gids)
-    free(gids);
+  free(uids);
+  free(gids);
   return retval;
 }
 

--- a/pslib_osx.c
+++ b/pslib_osx.c
@@ -70,9 +70,7 @@ static CpuTimes *per_cpu_times() {
   return ret;
 
 error:
-  if (ret) {
-    free(ret);
-  }
+  free(ret);
   if (cpu_load_info != NULL) {
     sysret = vm_deallocate(mach_task_self(), (vm_address_t)info_array,
                            info_count * pagesize);
@@ -116,9 +114,7 @@ static CpuTimes *calculate_cpu_times_percentage(CpuTimes *t1, CpuTimes *t2) {
   return ret;
 
 error:
-  if (ret) {
-    free(ret);
-  }
+  free(ret);
   return NULL;
 }
 
@@ -316,12 +312,8 @@ static char *get_cmdline(pid_t pid) {
   }
 
 error:
-  if (procargs) {
-    free(procargs);
-  }
-  if (ret) {
-    free(ret);
-  }
+  free(procargs);
+  free(ret);
   return NULL;
 }
 
@@ -526,8 +518,7 @@ DiskPartitionInfo *disk_partitions(bool physical) {
   return ret;
 
 error:
-  if (fs != NULL)
-    free(fs);
+  free(fs);
   free_disk_partition_info(ret);
   return NULL;
 }
@@ -748,14 +739,9 @@ NetIOCounterInfo *net_io_counters() {
   return ret;
 
 error:
-  if (buf != NULL)
-    free(buf);
-  if (counters) {
-    free(counters);
-  }
-  if (nc) {
-    free(nc);
-  }
+  free(buf);
+  free(counters);
+  free(nc);
   return NULL;
 }
 
@@ -803,9 +789,7 @@ CpuTimes *cpu_times(bool percpu) {
   }
 
 error:
-  if (ret) {
-    free(ret);
-  }
+  free(ret);
   return NULL;
 }
 
@@ -824,9 +808,7 @@ double *cpu_util_percent(bool percpu, CpuTimes *prev_times) {
   free(current);
   return percentage;
 error:
-  if (current) {
-    free(current);
-  }
+  free(current);
   return NULL;
 }
 
@@ -848,9 +830,7 @@ CpuTimes *cpu_times_percent(bool percpu, CpuTimes *prev_times) {
   free(current);
   return ret;
 error:
-  if (current) {
-    free(current);
-  }
+  free(current);
   return NULL;
 }
 
@@ -978,10 +958,8 @@ Process *get_process(pid_t pid) {
   }
 
   retval->terminal = get_terminal(pid);
-  if (uids)
-    free(uids);
-  if (gids)
-    free(gids);
+  free(uids);
+  free(gids);
   return retval;
 }
 

--- a/pslib_osx.c
+++ b/pslib_osx.c
@@ -410,11 +410,11 @@ DiskPartitionInfo *disk_partitions(bool physical) {
   char opts[400];
   struct statfs *fs = NULL;
   uint32_t nparts = 5;
+  DiskPartitionInfo *ret = NULL;
 
   DiskPartition *partitions =
       (DiskPartition *)calloc(nparts, sizeof(DiskPartition));
-  DiskPartitionInfo *ret =
-      (DiskPartitionInfo *)calloc(1, sizeof(DiskPartitionInfo));
+  ret = (DiskPartitionInfo *)calloc(1, sizeof(DiskPartitionInfo));
   DiskPartition *d = partitions;
   check_mem(partitions);
   check_mem(ret);
@@ -677,14 +677,15 @@ NetIOCounterInfo *net_io_counters() {
   int32_t mib[6];
   size_t len;
   int32_t ninterfaces = 0;
-
-  NetIOCounterInfo *ret =
-      (NetIOCounterInfo *)calloc(1, sizeof(NetIOCounterInfo));
-  NetIOCounters *counters = (NetIOCounters *)calloc(15, sizeof(NetIOCounters));
-  NetIOCounters *nc = counters;
+  NetIOCounterInfo *ret = NULL;
+  NetIOCounters *counters = NULL;
+  NetIOCounters *nc = NULL;
+  ret = (NetIOCounterInfo *)calloc(1, sizeof(NetIOCounterInfo));
+  counters = (NetIOCounters *)calloc(15, sizeof(NetIOCounters));
 
   check_mem(ret);
   check_mem(counters);
+  nc = counters;
 
   mib[0] = CTL_NET;        // networking subsystem
   mib[1] = PF_ROUTE;       // type of information


### PR DESCRIPTION
- Calling `free()` on a `NULL` pointer is treated as a no-op. Checking a pointer before invoking `free()` serves no purpose.
- Invoking `fclose()` does not modify the file pointer value.  Explicitly setting it it to `NULL` makes its state clear and possible double free can be avoided.
