### PR TITLE
Cast ret to size_t from ssize_t

### DIFF
--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -254,7 +254,7 @@ static char *get_exe(pid_t pid) {
     }
   }
   check(ret != -1, "Couldn't expand symbolic link");
-  while (ret == bufsize - 1) {
+  while ((size_t) ret == bufsize - 1) {
     /* Buffer filled. Might be incomplete. Increase size and try again. */
     bufsize *= 2;
     tmp = (char *)realloc(tmp, bufsize);
@@ -389,7 +389,7 @@ static char *get_terminal(pid_t pid) {
   check_mem(tmp);
   ret = readlink(procfile, tmp, bufsize - 1);
   check(ret != -1, "Couldn't expand symbolic link");
-  while (ret == bufsize - 1) {
+  while ((size_t) ret == bufsize - 1) {
     /* Buffer filled. Might be incomplete. Increase size and try again. */
     bufsize *= 2;
     tmp = (char *)realloc(tmp, bufsize);


### PR DESCRIPTION
Comparison between signed and unsigned int on ARM leads to 'sign-compare' error.

```
gcc -O0 -g -std=gnu11 -fPIC -march=native -Wall -Wextra -Wunused -Werror -Wshadow -fprofile-arcs -ftest-coverage   -c -o pslib_linux.o pslib_linux.c    
pslib_linux.c: In function ‘get_exe’:                        
pslib_linux.c:257:14: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]            
   while (ret == bufsize - 1) {                              
              ^               
pslib_linux.c: In function ‘get_terminal’:                   
pslib_linux.c:392:14: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]            
   while (ret == bufsize - 1) {                              
              ^               
cc1: all warnings being treated as errors                    
<builtin>: recipe for target 'pslib_linux.o' failed          
make: *** [pslib_linux.o] Error 1
```

I'm not sure if this fix is entirely safe.